### PR TITLE
Fix incorrect version of WebSocketClient instance being used.

### DIFF
--- a/bot_sample.go
+++ b/bot_sample.go
@@ -64,7 +64,7 @@ func main() {
 	SendMsgToDebuggingChannel("_"+SAMPLE_NAME+" has **started** running_", "")
 
 	// Lets start listening to some channels via the websocket!
-	webSocketClient, err := model.NewWebSocketClient("ws://localhost:8065", client.AuthToken)
+	webSocketClient, err := model.NewWebSocketClient4("ws://localhost:8065", client.AuthToken)
 	if err != nil {
 		println("We failed to connect to the web socket")
 		PrintError(err)


### PR DESCRIPTION
API v4 requires the use of NewWebSocketClient4 instead
NewWebSocketClient.
Now that APIv3 is still supported this is not an issue, but this hides
the problem until the APIv3 is officially dropped. Where trying to
connect to APIv4 using this constructor will lead to a panic without
giving clear information about the problem ("websocket: bad handshake").

This can be reproduced by changing "Allow use of API v3 endpoints" to false in a Mattermost instance config.json.