### PR TITLE
Track mattermost repo structure in dependencies

### DIFF
--- a/bot_sample.go
+++ b/bot_sample.go
@@ -9,7 +9,7 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/mattermost/platform/model"
+	"github.com/mattermost/mattermost-server/model"
 )
 
 const (

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,6 +1,6 @@
 package: github.com/mattermost/mattermost-bot-sample-golang
 import:
-- package: github.com/mattermost/platform
+- package: github.com/mattermost/mattermost-server
   version: master
   subpackages:
   - model


### PR DESCRIPTION
Updates the example to reference `mattermost/mattermost-server` instead of `mattermost/platform`